### PR TITLE
Changed display on opponent cards

### DIFF
--- a/src/components/OpponentHand.tsx
+++ b/src/components/OpponentHand.tsx
@@ -95,7 +95,7 @@ export const OppponentHand = ({
             />
           </svg>
         </div>
-        <p className={`${gf.otherplayerName}`}>{p.playerIdentity.name}</p>
+        <p className={`${gf.otherplayerName}`}>{game.players[playerId].displayName}</p>
       </div>
     </div>
   );


### PR DESCRIPTION
Their roles were being displayed on the back of the cards instead of their name.